### PR TITLE
add: recipes, ingredients and tags filtering.

### DIFF
--- a/app/recipe/tests/test_ingredients_api.py
+++ b/app/recipe/tests/test_ingredients_api.py
@@ -1,6 +1,8 @@
 """
 Tests for the ingredients API.
 """
+from decimal import Decimal
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.test import TestCase
@@ -8,7 +10,10 @@ from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from core.models import Ingredient
+from core.models import (
+    Ingredient,
+    Recipe,
+)
 
 from recipe.serializers import IngredientSerializer
 
@@ -102,3 +107,48 @@ class PrivateIngredientsAPITests(TestCase):
         self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
         ingredients = Ingredient.objects.filter(user=self.user)
         self.assertFalse(ingredients.exists())
+
+    def test_filter_assigned_to_recipes(self):
+        """Tests listing ingredients by those assigned to recipes."""
+        in1 = Ingredient.objects.create(user=self.user, name='Tortilla')
+        in2 = Ingredient.objects.create(user=self.user, name='Nopales')
+        recipe = Recipe.objects.create(
+            user=self.user,
+            title='Chilaquiles',
+            time_minutes=28,
+            price=Decimal('78.25'),
+        )
+        recipe.ingredients.add(in1)
+
+        res = self.client.get(INGREDIENTS_URL, {'assigned_only': 1})
+
+        s1 = IngredientSerializer(in1)
+        s2 = IngredientSerializer(in2)
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertIn(s1.data, res.data)
+        self.assertNotIn(s2.data, res.data)
+
+    def test_filtered_ingredients_unique(self):
+        """Tests filtered ingredients returns a unique list."""
+        ing = Ingredient.objects.create(user=self.user, name='Huevos')
+        Ingredient.objects.create(user=self.user, name='Fresas')
+        recipe1 = Recipe.objects.create(
+            user=self.user,
+            title='Huevos motuleños',
+            price=Decimal('65.23'),
+            time_minutes=12,
+        )
+        recipe2 = Recipe.objects.create(
+            user=self.user,
+            title='Huevos divorciados',
+            price=Decimal('58.99'),
+            time_minutes=9,
+        )
+        recipe1.ingredients.add(ing)
+        recipe2.ingredients.add(ing)
+
+        res = self.client.get(INGREDIENTS_URL, {'assigned_only': 1})
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(res.data), 1)

--- a/app/recipe/tests/test_recipe_api.py
+++ b/app/recipe/tests/test_recipe_api.py
@@ -438,6 +438,50 @@ class PrivateRecipeAPITest(TestCase):
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(recipe.ingredients.count(), 0)
 
+    def test_filter_by_tags(self):
+        """Tests filtering recipes by tags."""
+        r1 = create_recipe(user=self.user, title='Guacamole')
+        r2 = create_recipe(user=self.user, title='Quesadillas')
+        tag1 = Tag.objects.create(user=self.user, name='vegan')
+        tag2 = Tag.objects.create(user=self.user, name='mexican')
+        r1.tags.add(tag1)
+        r2.tags.add(tag2)
+        r3 = create_recipe(user=self.user, title='Reubens Sandwich')
+
+        params = {'tags': f'{tag1.id},{tag2.id}'}
+        res = self.client.get(RECIPES_URL, params)
+
+        s1 = RecipeSerializer(r1)
+        s2 = RecipeSerializer(r2)
+        s3 = RecipeSerializer(r3)
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertIn(s1.data, res.data)
+        self.assertIn(s2.data, res.data)
+        self.assertNotIn(s3.data, res.data)
+
+    def test_filter_by_ingredients(self):
+        """Tests filtering recipes by ingredients."""
+        r1 = create_recipe(user=self.user, title='Frijol con puerco')
+        r2 = create_recipe(user=self.user, title='Margarita')
+        i1 = Ingredient.objects.create(user=self.user, name='Frijol negro')
+        i2 = Ingredient.objects.create(user=self.user, name='Tequila')
+        r1.ingredients.add(i1)
+        r2.ingredients.add(i2)
+        r3 = create_recipe(user=self.user, title='Pizza Margarita')
+
+        params = {'ingredients': f'{i1.id},{i2.id}'}
+        res = self.client.get(RECIPES_URL, params)
+
+        s1 = RecipeSerializer(r1)
+        s2 = RecipeSerializer(r2)
+        s3 = RecipeSerializer(r3)
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertIn(s1.data, res.data)
+        self.assertIn(s2.data, res.data)
+        self.assertNotIn(s3.data, res.data)
+
 
 class ImageUploadTests(TestCase):
     """Tests for the image upload API."""

--- a/app/recipe/tests/test_tags_api.py
+++ b/app/recipe/tests/test_tags_api.py
@@ -1,6 +1,8 @@
 """
 Tests for the tags API.
 """
+from decimal import Decimal
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.test import TestCase
@@ -8,7 +10,10 @@ from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from core.models import Tag
+from core.models import (
+    Tag,
+    Recipe,
+)
 
 from recipe.serializers import TagSerializer
 
@@ -100,3 +105,48 @@ class PrivateTagsAPITests(TestCase):
         self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
         tags = Tag.objects.filter(user=self.user)
         self.assertFalse(tags.exists())
+
+    def test_filter_tags_assigned_to_recipe(self):
+        """Tests listing tags by those assigned to recipes."""
+        tag1 = Tag.objects.create(user=self.user, name='sopas')
+        tag2 = Tag.objects.create(user=self.user, name='cockteles')
+        recipe = Recipe.objects.create(
+            user=self.user,
+            title='Arroz a la veracruzana',
+            time_minutes=40,
+            price=Decimal('37.28'),
+        )
+        recipe.tags.add(tag1)
+
+        res = self.client.get(TAGS_URL, {'assigned_only': 1})
+
+        s1 = TagSerializer(tag1)
+        s2 = TagSerializer(tag2)
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertIn(s1.data, res.data)
+        self.assertNotIn(s2.data, res.data)
+
+    def test_filtered_tags_unique(self):
+        """Tests filtered tags returns a unique list."""
+        tag = Tag.objects.create(user=self.user, name='desayuno')
+        Tag.objects.create(user=self.user, name='ron')
+        recipe1 = Recipe.objects.create(
+            user=self.user,
+            title='Hotcakes',
+            time_minutes=17,
+            price=Decimal('33.23'),
+        )
+        recipe2 = Recipe.objects.create(
+            user=self.user,
+            title='Waffles',
+            time_minutes=18,
+            price=Decimal('34.28'),
+        )
+        recipe1.tags.add(tag)
+        recipe2.tags.add(tag)
+
+        res = self.client.get(TAGS_URL, {'assigned_only': 1})
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(res.data), 1)

--- a/app/recipe/views.py
+++ b/app/recipe/views.py
@@ -1,6 +1,12 @@
 """
 Views for the recipe APIs.
 """
+from drf_spectacular.utils import (
+    extend_schema_view,
+    extend_schema,
+    OpenApiParameter,
+    OpenApiTypes,
+)
 from rest_framework import (
     viewsets,
     mixins,
@@ -15,6 +21,24 @@ from core.models import Recipe, Tag, Ingredient
 from recipe import serializers
 
 
+@extend_schema_view(
+    list=extend_schema(
+        parameters=[
+            OpenApiParameter(
+                'tags',
+                OpenApiTypes.STR,
+                description="""Comma separated list of tags IDs
+                to filter recipes.""",
+            ),
+            OpenApiParameter(
+                'ingredients',
+                OpenApiTypes.STR,
+                description="""Comma separated list of ingredients IDs
+                to filter recipes.""",
+            )
+        ]
+    )
+)
 class RecipeViewSet(viewsets.ModelViewSet):
     """View for manage recipe APIs."""
     serializer_class = serializers.RecipeDetailSerializer
@@ -22,9 +46,27 @@ class RecipeViewSet(viewsets.ModelViewSet):
     authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticated]
 
+    def _params_to_ints(self, query_string):
+        """Converts a list of strings to integers."""
+        return [int(str_id) for str_id in query_string.split(',')]
+
     def get_queryset(self):
         """Retrieve recipes for authenticated user."""
-        return self.queryset.filter(user=self.request.user).order_by('-id')
+        tags = self.request.query_params.get('tags')
+        ingredients = self.request.query_params.get('ingredients')
+        queryset = self.queryset
+
+        if tags:
+            tag_ids = self._params_to_ints(tags)
+            queryset = queryset.filter(tags__id__in=tag_ids)
+
+        if ingredients:
+            ingredient_ids = self._params_to_ints(ingredients)
+            queryset = queryset.filter(ingredients__id__in=ingredient_ids)
+
+        return queryset.filter(
+            user=self.request.user
+        ).order_by('-id').distinct()
 
     def get_serializer_class(self):
         """Returns the serializer class for request."""
@@ -52,6 +94,17 @@ class RecipeViewSet(viewsets.ModelViewSet):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+@extend_schema_view(
+    list=extend_schema(
+        parameters=[
+            OpenApiParameter(
+                'assigned_only',
+                OpenApiTypes.INT, enum=[0, 1],
+                description="""Filter by items assigned to recipes.""",
+            )
+        ]
+    )
+)
 class BaseRecipeAttrViewSet(mixins.DestroyModelMixin,
                             mixins.UpdateModelMixin,
                             mixins.ListModelMixin,
@@ -63,7 +116,20 @@ class BaseRecipeAttrViewSet(mixins.DestroyModelMixin,
 
     def get_queryset(self):
         """Filters queryset to authenticated user."""
-        return self.queryset.filter(user=self.request.user).order_by('-name')
+        assigned_only = bool(
+            int(self.request.query_params.get('assigned_only', 0))
+        )
+
+        queryset = self.queryset
+
+        if assigned_only:
+            queryset = queryset.filter(recipe__isnull=False)
+
+        return queryset.filter(
+            user=self.request.user
+        ).order_by(
+            '-name'
+        ).distinct()
 
 
 class TagViewSet(BaseRecipeAttrViewSet):


### PR DESCRIPTION
Now recipes can be filtered by a list of tags IDs and or ingredients IDs. Ingredients and tags can also be filtered by assigned_only parameter (only if there are recipes that contain those ingredients or tags)